### PR TITLE
read and write Pharao format

### DIFF
--- a/src/main/java/AlignFrame.java
+++ b/src/main/java/AlignFrame.java
@@ -1,38 +1,51 @@
-import java.lang.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.*;
-import java.awt.*;
-import java.awt.event.*;
-import java.util.*;
 
 import javax.swing.*;
 
 public class AlignFrame extends JFrame{
-	public AlignFrame(Bitext b, String enc) {
+    
+	public AlignFrame(Bitext b, String enc, String alignmentPath) {
 		super("Alignment UI");
 		setSize(1000, 900);
 
 		AlignMainContent main_pane = new AlignMainContent(b, enc);
 		getContentPane().add(main_pane.createComponents());
 
-		// Exit the application when the window is closed.
-		setDefaultCloseOperation(AlignFrame.EXIT_ON_CLOSE);
+		setDefaultCloseOperation(AlignFrame.DO_NOTHING_ON_CLOSE);
+                this.addWindowListener(new WindowAdapter() {
+                    @Override
+                    public void windowClosing(WindowEvent event) {
+                        if( b.getUpdated() ){
+                            System.out.println("Bitext has changed, writing alignments...");
+                            try {
+                                b.writePairs(alignmentPath);
+                            } catch (FileNotFoundException ex) {
+                                System.out.println("ERROR writing alignments: "+ex);
+                            }
+                        }else{
+                            System.out.println("Bitext has not changed.");
+                        }
+                        System.exit(0);
+                    }
+                });
+                
 		pack();
 		setVisible(true);
 	}
 
 	public static void main(String argv[]) throws IOException, ClassNotFoundException {
 
-		if (argv.length < 2 ) {
-		    System.out.println("usage -- java -jar align_ui.jar <enfile> <frfile> [encoding] [sentence no.]");
+		if (argv.length < 3 ) {
+		    System.out.println("usage -- java -jar align_ui.jar <enfile> <frfile> <alignments> [encoding]");
 		    System.exit(0);
 		}
 
-		Sentence es, cs;
-		String encoding;
-
 		// get the encoding if provided otherwise use UTF-8 as the default encoding
-		if (argv.length == 3) {
-			encoding = argv[2];
+                String encoding;
+		if (argv.length == 4) {
+			encoding = argv[3];
 		}
 		else {
 			encoding = "UTF-8";
@@ -41,21 +54,34 @@ public class AlignFrame extends JFrame{
 		// data structure for holding parallel sentences
 		Bitext b = new Bitext(encoding);
 
-		// get the starting setence number
-		if (argv.length == 4)
-			b.setSentID(Integer.parseInt(argv[3]));
-
-
 		// read all the sentences into the Bitext (parallel vectors) structure
-		ReadInput ef = new ReadInput(argv[0], "UTF-8");
+		ReadInput ef = new ReadInput(argv[0], encoding);
 		ReadInput cf = new ReadInput(argv[1], encoding);
-
+                ReadInput af;
+                try{
+                    af = new ReadInput(argv[2], encoding);
+                }catch( FileNotFoundException ex){
+                    af = null;
+                }
+                
+                Sentence es, cs;
+                int id = 1;
 		while (((es = ef.readSent(true))!=null) &&
 			   ((cs = cf.readSent(false))!=null)) {
-			b.add_sent_pair(es, cs);
+                    Pair p = new Pair(es, cs, id++, b.enc);
+                    if( af != null ){
+                        af.readLinkSets(p, b);
+                    }
+                    b.add_sent_pair(p);
 		}
 
-		new AlignFrame(b, encoding);
+                ef.closeFile();
+                cf.closeFile();
+                if( af != null ){
+                    af.closeFile();
+                }
+                
+                new AlignFrame(b, encoding, argv[2]);
 	}
 }
 

--- a/src/main/java/AlignMainContent.java
+++ b/src/main/java/AlignMainContent.java
@@ -1,5 +1,3 @@
-import java.lang.*;
-import java.util.*;
 import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
@@ -118,6 +116,7 @@ public class AlignMainContent {
 		undo.addActionListener(new ActionListener() {
 				public void actionPerformed(ActionEvent e) {
 					bitext.resetLinkSet();
+                                        bitext.setUpdated();
 				}
 			});
 		
@@ -127,9 +126,9 @@ public class AlignMainContent {
 				public void actionPerformed(ActionEvent e) {
 					// write the links to memory and to file
 					Pair p = bitext.getPair();
-					p.addLinkSet(bitext.active_linkset, p.alignment);
-					p.writeToFile();
-					bitext.newLinkSet();  
+					p.addLinkSet(bitext.active_linkset);
+					bitext.newLinkSet();
+                                        bitext.setUpdated();
 				}
 			});
 
@@ -139,8 +138,7 @@ public class AlignMainContent {
         next_button.addActionListener(new ActionListener() {
 				public void actionPerformed(ActionEvent e) {
 					Pair p = bitext.getPair();
-					p.addLinkSet(bitext.active_linkset, p.alignment);
-					p.writeToFile();
+					p.addLinkSet(bitext.active_linkset);
 					if (sentID < bitext.size()) {
 						bitext.newLinkSet(); // flush active linkset
 						bitext.setSentID(++sentID);
@@ -155,8 +153,7 @@ public class AlignMainContent {
         prev_button.addActionListener(new ActionListener() {
 				public void actionPerformed(ActionEvent e) {
 					Pair p = bitext.getPair();
-					p.addLinkSet(bitext.active_linkset, p.alignment);
-					p.writeToFile();
+					p.addLinkSet(bitext.active_linkset);
 					if (sentID>1) {
 						bitext.newLinkSet(); // flush active linkset
 						bitext.setSentID(--sentID);

--- a/src/main/java/Bitext.java
+++ b/src/main/java/Bitext.java
@@ -1,74 +1,126 @@
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.util.*;
 
 public class Bitext extends Observable {
-	private int num_sents;
-	private int cur_sentID;
-	private Vector pairs = new Vector();
-	String  enc;
 
-	LinkSet active_linkset;
+    private int num_sents;
+    private int cur_sentID;
+    private final List<Pair> pairs = new ArrayList<>();
+    String enc;
+    private boolean updated = false;
+    LinkSet active_linkset;
 
-	public Bitext(String e) {
-		enc       = e;
-		num_sents = 0;
-		cur_sentID = 1;  
-		active_linkset = new LinkSet(this);  // init 
-	}
+    public Bitext(String e) {
+        enc = e;
+        num_sents = 0;
+        cur_sentID = 1;
+        active_linkset = new LinkSet(this);  // init 
+    }
 
-	public void add_sent_pair(Sentence e, Sentence c) {
-		pairs.addElement(new Pair(e, c, ++num_sents, this));
-	}
-	
-	public int size() {
-		return num_sents;
-	}
+    public void add_sent_pair(Pair p) {
+        pairs.add(p);
+        num_sents++;
+    }
 
-	public Pair getPair() {
-		return ((Pair)pairs.elementAt(cur_sentID-1));
-	}
+    public int size() {
+        return num_sents;
+    }
 
-	public Sentence getEngSent () {
-		return getPair().getEngSent();
-	}
-	
-	public Sentence getChSent () {
-		return getPair().getChSent();
-	}
-	
-	public String getEngStr () {
-		return (getEngSent().getStr());
-	}
+    public Pair getPair() {
+        return pairs.get(cur_sentID - 1);
+    }
+    
+    public List<Pair> getPairs() {
+        return pairs;
+    }
 
-	public String getChStr () {
-		return (getChSent().getStr());
-	}
+    public Sentence getEngSent() {
+        return getPair().getEngSent();
+    }
 
-	public int getSentID() {
-		return cur_sentID;
-	}
-	
-	public void setSentID(int i) {
-		cur_sentID = i;
-		changed();
-	}
+    public Sentence getChSent() {
+        return getPair().getChSent();
+    }
 
-	public void newLinkSet() {
-		active_linkset = new LinkSet(this);
-		changed();
-	}
+    public String getEngStr() {
+        return (getEngSent().getStr());
+    }
 
-	public void resetLinkSet() {
-		active_linkset.reset();
-		changed();
-	}
+    public String getChStr() {
+        return (getChSent().getStr());
+    }
 
-	public void setLinkSet(LinkSet l) {
-		active_linkset = l;
-		changed();
-	}
+    public int getSentID() {
+        return cur_sentID;
+    }
 
-	public void changed() {
-		setChanged();
-		notifyObservers();
-	}
+    public void setSentID(int i) {
+        cur_sentID = i;
+        changed();
+    }
+
+    public void newLinkSet() {
+        active_linkset = new LinkSet(this);
+        changed();
+    }
+
+    public void resetLinkSet() {
+        active_linkset.reset();
+        changed();
+    }
+
+    public void setLinkSet(LinkSet l) {
+        active_linkset = l;
+        changed();
+    }
+
+    public void changed() {
+        setChanged();
+        notifyObservers();
+    }
+    
+    public boolean getUpdated(){
+        return updated;
+    }
+    
+    public void setUpdated(){
+        updated = true;
+    }
+
+    public void writePairs(String alignmentPath) throws FileNotFoundException {
+        FileOutputStream stream = new FileOutputStream(alignmentPath);
+        OutputStreamWriter writer;
+        try {
+            writer = new OutputStreamWriter(stream, enc);
+        } catch (UnsupportedEncodingException e) {
+            System.out.println("encoding not supported");
+            writer = new OutputStreamWriter(stream);
+        }
+        PrintWriter printer = new PrintWriter(writer);
+            
+        for (Pair p : pairs) {
+            int e = 0;
+            while (e < p.alignment.size()) {
+                LinkSet linkset = (LinkSet) p.alignment.elementAt(e);
+                if (linkset.is_empty()) {
+                    p.alignment.removeElementAt(e);
+                } else {
+                    for (Iterator i = linkset.getLinks().iterator(); i.hasNext();) {
+                        Link l = (Link) i.next();
+                        if( e > 0 ){
+                            printer.print(" ");
+                        }
+                        printer.print(l.eng.getPosition() + "-" + l.ch.getPosition());
+                    }   
+                    e++;
+                }
+            }
+            printer.println();
+        }
+        printer.close();
+    }
 }

--- a/src/main/java/Link.java
+++ b/src/main/java/Link.java
@@ -1,4 +1,5 @@
-import java.util.*;
+import java.util.Iterator;
+import java.util.Vector;
 
 public class Link {
 	Word eng;

--- a/src/main/java/Pair.java
+++ b/src/main/java/Pair.java
@@ -1,4 +1,3 @@
-import java.io.*;
 import java.util.*;
 
 public class Pair {
@@ -9,53 +8,13 @@ public class Pair {
 	Vector  user1 = new Vector();
 	Vector  user2 = new Vector();
 	Vector  user3 = new Vector();
-	ReadInput afile;
 	String  enc;
 
-	public Pair(Sentence e, Sentence c, int i, Bitext b) {
-		enc   = b.enc;
+	public Pair(Sentence e, Sentence c, int i, String enc) {
+		this.enc   = enc;
 		esent = e;
 		csent = c;
 		pair_id = i;
-		try {  
-			// System.out.println ("reading in user1");
-			// get alignments from user1
-			afile = new ReadInput("annotator1/aligned."+pair_id, enc);
-			afile.readFLS(this, b, user1);
-
-			// get alignments from user2
-			afile = new ReadInput("annotator2/aligned."+pair_id, enc);
-			afile.readFLS(this, b, user2);
-
-			afile = new ReadInput("gold/aligned."+pair_id, enc);
-			afile.readFLS(this, b, user3);
-
-			// move common links between user1 and user2 to alignment
-			for (int id1=0; id1<user1.size();) {
-				FauxLS fls = (FauxLS)user1.elementAt(id1);
-				int id2 = find_fls(fls, user2);
-				if (id2 != -1) {
-					user1.removeElementAt(id1);
-					user2.removeElementAt(id2);
-					addLinkSet(fls.toLinkSet(), alignment);
-				}
-				else id1++;
-			}
-		}
-		catch (IOException ex) {
-			//			System.out.println ("failed to read in user files");
-			afile = null;
-		}
-		try{
-			afile = new ReadInput("aligned."+pair_id, enc);
-			afile.readLinkSets(this, b, alignment);
-		}
-		catch (IOException ex) {
-			afile = null;
-		}
-		//		System.out.println ("there are "+user1.size()+" elements in user1");
-		//		System.out.println ("there are "+user2.size()+" elements in user2");
-		//		System.out.println ("there are "+alignment.size()+" elements in alignment");
 	}
 	
 	public Sentence getEngSent() {
@@ -89,11 +48,10 @@ public class Pair {
 		return -1;
 	}
 
-	public void addLinkSet (LinkSet ls, Vector v) {
-		// if ls isn't already in v (i.e., alignment),
-		// add it to the list
-		if ((!ls.is_empty()) && (v.indexOf(ls) == -1))
-			v.addElement(ls);
+	public void addLinkSet (LinkSet ls) {
+		// if ls isn't already in alignment, add it to the list
+		if ((!ls.is_empty()) && (alignment.indexOf(ls) == -1))
+			alignment.addElement(ls);
 
 		// need to maintain the user lists:
 		// if the words in ls appears in either user1 or user2, remove that element
@@ -113,41 +71,5 @@ public class Pair {
 		// add it to the list
 		if ((!l.is_empty()) && (v.indexOf(l) == -1))
 			v.addElement(l);
-	}
-	
-	public void writeToFile() {
-		try{
-			FileOutputStream stream   = new FileOutputStream("aligned."+pair_id);
-			OutputStreamWriter writer;
-			try{
-				writer = new OutputStreamWriter(stream, enc);
-			}
-			catch (UnsupportedEncodingException e) { 
-				System.out.println ("encoding not supported");
-				writer = new OutputStreamWriter(stream);
-			}
-			PrintWriter printer       = new PrintWriter(writer);
-
-			int e=0; 
-			while (e<alignment.size()) {
-				LinkSet linkset = (LinkSet)alignment.elementAt(e);
-				if (linkset.is_empty()) {
-					alignment.removeElementAt(e);
-				}
-				else {
-					for (Iterator i= linkset.getLinks().iterator(); i.hasNext();) {
-						Link l = (Link)i.next();
-						printer.print (l.eng.getPosition()+"  "+l.ch.getPosition()+"  (") ;
-						printer.print (l.eng.getLabel()+", "+l.ch.getLabel()+")    ");
-					}
-					printer.println();
-					e++;
-				}
-			}
-			printer.close();
-		}
-		catch(IOException e) {
-			System.exit(0);
-		}
 	}
 }

--- a/src/main/java/ReadInput.java
+++ b/src/main/java/ReadInput.java
@@ -1,137 +1,57 @@
 import java.io.*;
-import java.util.*;
 
-public class ReadInput{
-	private String fname;
-	private String enc;
-	private FileInputStream   stream ; 
-	private InputStreamReader reader ;
-	private BufferedReader    bReader;
+public class ReadInput {
 
-	public ReadInput(String f, String e) throws IOException, UnsupportedEncodingException {
-		fname = f;
-		enc   = e;
-		openFile();
-	}
-	
-	public void openFile() throws IOException, UnsupportedEncodingException {
-		stream  = new FileInputStream(fname);
-		reader  = new InputStreamReader(stream, enc);
-		bReader = new BufferedReader(reader);
-	}
-	
-	public void closeFile() throws IOException {
-		stream.close();
-	}
+    private final BufferedReader bReader;
 
-	// returns a vector of String tokens in one line of the file
-	// delimited by space; returns null if eof
-	public Vector split() throws IOException{
-		int ch;
-		StringBuffer buff = null;
-		Vector toks = new Vector();
+    public ReadInput(String fname, String enc) throws IOException, UnsupportedEncodingException {
+        bReader = new BufferedReader(new InputStreamReader(new FileInputStream(fname), enc));
+    }
 
-		while ((ch=bReader.read()) != -1) {
-			if ((char)ch == '\n') {
-				if (buff != null) 
-					toks.addElement(buff.toString());
-				return toks;
-			}
-			else if (((char)ch != ' ') && ((char)ch != '\t')) {
-				if (buff == null)
-					buff = new StringBuffer();
-				buff.append((char)ch);
-			}
-			else if (buff != null) {
-				toks.addElement(buff.toString());
-				buff = null;
-			}
-		}
-		// end of file
-		if (toks.size()>0)
-			return toks;
-		else return null;
-	}
+    public void closeFile() throws IOException {
+        bReader.close();
+    }
 
-	
-	public Sentence readSent(boolean bEng) throws IOException {
-		Sentence s = new Sentence(bEng);
-		int ch;
-		StringBuffer word = null;
-		
-		while ((ch=bReader.read()) != -1) {
-			if ((char)ch == '\n') {
-				if (word != null) 
-					s.addWord(word.toString());
-				return s;
-			}
-			else if (((char)ch != ' ') && ((char)ch != '\t')) {
-				if (word == null)
-					word = new StringBuffer();
-				word.append((char)ch);
-			}
-			else if (word != null) {  // ch == delimiter and we have been building a word
-				s.addWord(word.toString());
-				word = null;  // done with the word
-			}
-		}
-		// end of file
-		closeFile();
-		return null;
-	}
+    public Sentence readSent(boolean bEng) throws IOException {
+        Sentence s = null;
+        String line;
+        while ((line = bReader.readLine()) != null) {
+            String[] words = line.trim().split("\\s+");
+            s = new Sentence(bEng);
+            for (String word : words) {
+                s.addWord(word);
+            }
+            break;
+        }
+        if (s == null) {
+            closeFile();
+        }
+        return s;
+    }
 
-	public void readLinkSets(Pair p, Bitext b, Vector lsv) throws IOException{
-		Vector   v;
-		
-		while ((v = split())!=null) {
-			Vector   w = new Vector();
-			LinkSet ls = new LinkSet(b);
-
-			int i=0;
-			while (i+3<v.size()) {
-				// String se = (String)v.elementAt(i);
-				// String sc = (String)v.elementAt(i+1);
-				int ie = Integer.parseInt(((String)v.elementAt(i)));
-				int ic = Integer.parseInt(((String)v.elementAt(i+1)));
-				Word we = p.getEngSent().getWordAt(ie);
-				Word wc = p.getChSent().getWordAt(ic);
-				if (ls.eConnect.indexOf(we) == -1) 
-					ls.addWord(we);
-				if (ls.cConnect.indexOf(wc) == -1) 
-					ls.addWord(wc);
-				i+=4;
-			}
-			p.addLinkSet(ls, lsv);
-		}		
-		//		System.out.println ("-----------------------");
-	}
-
-	// reads from file and put into a vector called flsv, whose
-	// elements should be of FauxLS type
-	public void readFLS(Pair p, Bitext b, Vector flsv) throws IOException{
-		Vector   v;
-		
-		while ((v = split())!=null) {
-			Vector    w = new Vector();
-			FauxLS  fls = new FauxLS(b);
-			
-			int i=0;
-			while (i+3<v.size()) {
-				// String se = (String)v.elementAt(i);
-				// String sc = (String)v.elementAt(i+1);
-				int ie = Integer.parseInt(((String)v.elementAt(i)));
-				int ic = Integer.parseInt(((String)v.elementAt(i+1)));
-				Word we = p.getEngSent().getWordAt(ie);
-				Word wc = p.getChSent().getWordAt(ic);
-				if (fls.eConnect.indexOf(we) == -1) 
-					fls.addWord(we);
-				if (fls.cConnect.indexOf(wc) == -1) 
-					fls.addWord(wc);
-				i+=4;
-			}
-			p.addFauxLS(fls, flsv);
-		}		
-		//		System.out.println ("-----------------------");
-	}
-
+    public void readLinkSets(Pair p, Bitext b) throws IOException {
+        
+        String line;
+        while ((line = bReader.readLine()) != null) {
+            String[] alignments = line.trim().split("\\s+");
+            for( String alignment : alignments ){
+                LinkSet ls = new LinkSet(b);
+                String[] indices = alignment.split("-");
+                if( indices.length > 1 ){
+                    int ie = Integer.parseInt(indices[0]);
+                    int ic = Integer.parseInt(indices[1]);
+                    Word we = p.getEngSent().getWordAt(ie);
+                    Word wc = p.getChSent().getWordAt(ic);
+                    if (ls.eConnect.indexOf(we) == -1) {
+                        ls.addWord(we);
+                    }
+                    if (ls.cConnect.indexOf(wc) == -1) {
+                        ls.addWord(wc);
+                    }
+                    p.addLinkSet(ls);
+                }
+            }
+            break;
+        }
+    }
 }


### PR DESCRIPTION
This PR makes the wordalignui read and write a single alignment file in [Pharao](https://github.com/clab/fast_align#output) format. This format is used by [fast_align](https://github.com/clab/fast_align), [awesome-align](https://github.com/neulab/awesome-align), [OpenNMT](https://opennmt.net/OpenNMT-tf/alignments.html), and others.

The new usage is `java -jar wordalignui.jar <enfile> <frfile> <alignments> [encoding]` where `<enfile>` and `<frfile>` are the tokenized sentences (one sentence per line) of the two languages, and `<alignments>` is the file in Pharao format which can be empty. It can also contain empty lines (for sentences that are yet unaligned).

The alignment file is only written when the UI is closed.